### PR TITLE
Wrap dns.reverse in try/catch

### DIFF
--- a/appserver.js
+++ b/appserver.js
@@ -200,17 +200,22 @@ function getDomainName (clientIp, callback) { //11/14/15 by DW
 			}
 		}
 	else {
-		dns.reverse (clientIp, function (err, domains) {
-			var name = clientIp;
-			if (!err) {
-				if (domains.length > 0) {
-					name = domains [0];
+		try {
+			dns.reverse (clientIp, function (err, domains) {
+				var name = clientIp;
+				if (!err) {
+					if (domains.length > 0) {
+						name = domains [0];
+						}
 					}
-				}
+				if (callback !== undefined) {
+					callback (name);
+					}
+				});
+		} catch (err) {
 			if (callback !== undefined) {
-				callback (name);
+				callback (clientIp);
 				}
-			});
 		}
 	}
 function getDomainNameVerb (clientIp, callback) { //2/27/21 by DW


### PR DESCRIPTION
If an invalid IP address is passed to dns.reverse—for example, when receiving a IPv4-mapped IPv6 address like `::ffff:127.0.0.1`—it will throw instead of calling the callback with an error. See:

https://github.com/nodejs/node/issues/3112